### PR TITLE
fix(compress): key the result cache on intent, not content alone (query and level are silently ignored)

### DIFF
--- a/paritok/pipelines/compress.py
+++ b/paritok/pipelines/compress.py
@@ -209,8 +209,26 @@ class CompressionPipeline:
         # sid is deterministic (SHA256 of content), same value in cache check and store
         sid = content_hash(content)
 
-        # 4. Cache check (idempotent: same content always gets same sid)
-        cached = self.storage.get_cached_compressed(sid)
+        # The model is fed model_input when supplied, so kind must be classified
+        # from the same text. Doing it here rather than at step 5 lets the cache
+        # key carry the resolved kind instead of the caller's None.
+        model_text = model_input if model_input is not None else content
+        if kind is None:
+            kind = classify_kind_from_content(model_text)
+
+        # The compressed result depends on query, level and kind as well as on the
+        # content -- query is documented as driving keep/drop -- so all four belong
+        # in the key. Keying on content alone returned the first caller's answer to
+        # every later caller: a different intent and a different level came back
+        # byte-identical, with cache_hit=True and nothing to say which intent
+        # produced it. `sid` deliberately stays content-only, because expand_context
+        # resolves originals by content and that behaviour is correct.
+        cache_key = content_hash(
+            "\x00".join([sid, level or "", kind or "", query or ""])
+        )
+
+        # 4. Cache check (same content AND same intent gets the same answer)
+        cached = self.storage.get_cached_compressed(cache_key)
         if cached is not None:
             if source:
                 self.storage.set_shadow_for_path(source, sid)
@@ -223,15 +241,11 @@ class CompressionPipeline:
                 metadata={"cache_hit": True},
             )
 
-        # 5. Call model (SEG protocol: intent + kind + level). Feed model_input when
-        # given (e.g. line-numbered form) — content still governs everything else.
-        model_text = model_input if model_input is not None else content
-        # Classify kind centrally so every backend receives a real kind. Without
-        # this only LocalModelStrategy sniffs it internally; GpuServerStrategy would
-        # forward kind=None to the server. Classify on model_text (what the model
-        # actually sees), matching the local fallback.
-        if kind is None:
-            kind = classify_kind_from_content(model_text)
+        # 5. Call model (SEG protocol: intent + kind + level). model_text and kind
+        # are resolved above, before the cache key is built, so that every backend
+        # receives a real kind and the key reflects it. Without central
+        # classification only LocalModelStrategy sniffs kind internally;
+        # GpuServerStrategy would forward kind=None to the server.
         compressed = self._model.compress(
             model_text,
             query=query,
@@ -255,7 +269,7 @@ class CompressionPipeline:
             self.storage.set_shadow_for_path(source, sid)
         else:
             tagged = f"[REF:{sid}] {compressed}"
-        self.storage.cache_compressed(sid, tagged)
+        self.storage.cache_compressed(cache_key, tagged)
 
         tagged_tokens = count_tokens(tagged, enc)
 

--- a/tests/test_cache_key_intent.py
+++ b/tests/test_cache_key_intent.py
@@ -1,0 +1,92 @@
+"""Regression: the compressed-result cache was keyed on content alone.
+
+`sid = content_hash(content)` was used both as the shadow id and as the cache
+key, so the first caller's answer was returned to every later caller regardless
+of what they asked for:
+
+    query="Fix the IntegrityError"             level=L0  -> 159 tok, cache_hit=False
+    query="Explain the tax rounding TODO"      level=L3  -> 159 tok, cache_hit=True
+    identical output: yes
+
+That is worse than an ordinary stale-cache bug, because `query` is documented as
+"USER INTENT -- the agent's current task. Drives keep/drop." Query-conditioned
+compression stops happening the moment the same bytes are seen twice, which in a
+coding agent is constant: the same file across turns, the same test output after
+a re-run, the same schema every request.
+
+`level` was affected the same way, and it looks like "levels do nothing" -- L0
+through L3 come back byte-identical, and only the timings (9.6s, then 0.0s,
+0.0s, 0.0s) reveal it as a cache hit.
+
+The key now covers content, level, kind and query. `sid` stays content-only on
+purpose: expand_context resolves originals by content and that is correct.
+"""
+
+from paritok import CompressionPipeline, ParitokConfig
+
+CONTENT = (
+    '  File "app/db/session.py", line 214, in commit\n'
+    "sqlalchemy.exc.IntegrityError: duplicate key 0x1f4 violates \"orders_pkey\"\n"
+    "def compute_tax(amount, rate):\n    return amount * rate  # TODO rounding\n"
+) * 40
+
+
+class _RecordingModel:
+    """Returns a distinct answer per (query, level) so cache reuse is visible."""
+
+    def __init__(self):
+        self.calls = []
+
+    def compress(self, text, *, query=None, level=None, kind=None, **_):
+        self.calls.append((query, level, kind))
+        return f"compressed for query={query!r} level={level!r}"
+
+
+def _pipeline():
+    pipeline = CompressionPipeline(ParitokConfig.load())
+    model = _RecordingModel()
+    pipeline._model = model
+    return pipeline, model
+
+
+def test_a_different_query_is_not_served_from_cache():
+    pipeline, model = _pipeline()
+
+    first = pipeline.compress(CONTENT, query="Fix the IntegrityError", kind="tool_output")
+    second = pipeline.compress(CONTENT, query="Explain the rounding TODO", kind="tool_output")
+
+    assert first.metadata.get("cache_hit") is not True
+    assert second.metadata.get("cache_hit") is not True
+    assert first.compressed != second.compressed
+    assert len(model.calls) == 2, "the second intent must reach the model"
+
+
+def test_a_different_level_is_not_served_from_cache():
+    pipeline, model = _pipeline()
+
+    low = pipeline.compress(CONTENT, query="same", kind="tool_output", level="L0")
+    high = pipeline.compress(CONTENT, query="same", kind="tool_output", level="L3")
+
+    assert low.compressed != high.compressed
+    assert [c[1] for c in model.calls] == ["L0", "L3"]
+
+
+def test_an_identical_call_still_hits_the_cache():
+    """The fix must not turn the cache off."""
+    pipeline, model = _pipeline()
+
+    pipeline.compress(CONTENT, query="same", kind="tool_output", level="L1")
+    again = pipeline.compress(CONTENT, query="same", kind="tool_output", level="L1")
+
+    assert again.metadata.get("cache_hit") is True
+    assert len(model.calls) == 1, "an identical call must not reach the model twice"
+
+
+def test_shadow_id_stays_content_only():
+    """expand_context resolves by content; widening the cache key must not touch it."""
+    pipeline, _ = _pipeline()
+
+    first = pipeline.compress(CONTENT, query="one intent", kind="tool_output", level="L0")
+    second = pipeline.compress(CONTENT, query="another intent", kind="tool_output", level="L3")
+
+    assert first.shadow_id == second.shadow_id


### PR DESCRIPTION
`sid = content_hash(content)` served as both the shadow id **and** the cache key, so the first caller's answer is returned to every later caller regardless of what they asked for.

## Measured

Unique content, so the first call starts cold:

```
query="Fix the IntegrityError on commit"             level=L0  ->  159 tok  cache_hit=False
query="Explain the tax rounding TODO in compute_tax" level=L3  ->  159 tok  cache_hit=True

identical output: yes (544 chars both)
```

Two completely different intents, two different levels, one answer.

## Why this is worse than a stale cache

`compress()` documents the parameter as:

> `query`: USER INTENT — the agent's current task. **Drives keep/drop.**

Query-conditioned compression is the design. The cache stops it happening the moment the same bytes are seen twice — which in a coding agent is constant: the same file read across turns, the same test output after a re-run, the same tool schema in every request. The first intent to touch a file wins, and every later intent silently inherits its keep/drop decisions.

`level` is affected identically, and it presents as *"levels do nothing"*. I first measured L0–L3 as byte-identical across a corpus and nearly reported that instead. The timings gave it away:

```
L0  9.6s
L1  0.0s
L2  0.0s
L3  0.0s
```

## Fix

```python
sid = content_hash(content)                     # unchanged: the shadow id
cache_key = content_hash(
    "\x00".join([sid, level or "", kind or "", query or ""])
)
cached = self.storage.get_cached_compressed(cache_key)
```

`kind` is now classified before the lookup, so the key carries the resolved value rather than the caller's `None`.

**`sid` stays content-only on purpose.** `expand_context` resolves originals by content and that behaviour is correct — the shadow id is unchanged and stays identical across intents, which the tests assert. Only the compressed-result lookup widened.

## The trade, stated plainly

Including `query` lowers the hit rate, because queries vary more than content does. That is the cost of the parameter meaning what the docs say it means.

If that trade is unattractive, a documented `cache_key_includes_query: false` would at least make it a deliberate choice. What is hard to defend is the current silence: `metadata` reports `cache_hit: true` and says nothing about which intent produced the cached answer, so a caller cannot detect the substitution at all.

## Tests

Four regression cases using a recording stub model — a differing query, a differing level, an identical call still hitting the cache, and the shadow id staying content-only. **Full suite: 95 passing.**

---

Found while building [paritok-audit](https://github.com/EazyHood/paritok-audit) for the Build with Paritok hackathon. Separate from #15, which fixes the single-line chunking 400.

Disclosure: written with AI assistance; every measurement here was run on my own machine and I take responsibility for the change.
