### PR TITLE
fix(compress): intent-keyed result cache, with the path short-circuit kept working

### DIFF
--- a/paritok/pipelines/compress.py
+++ b/paritok/pipelines/compress.py
@@ -270,6 +270,11 @@ class CompressionPipeline:
         else:
             tagged = f"[REF:{sid}] {compressed}"
         self.storage.cache_compressed(cache_key, tagged)
+        # The path short-circuit (step 1b) intentionally reuses a prior [REF]
+        # tag for re-reads of the same source regardless of intent, and it
+        # looks the tag up by the content-only sid. Index the result there too,
+        # otherwise every re-read after this fix misses and re-invokes the model.
+        self.storage.cache_compressed(sid, tagged)
 
         tagged_tokens = count_tokens(tagged, enc)
 

--- a/paritok/pipelines/compress.py
+++ b/paritok/pipelines/compress.py
@@ -209,8 +209,26 @@ class CompressionPipeline:
         # sid is deterministic (SHA256 of content), same value in cache check and store
         sid = content_hash(content)
 
-        # 4. Cache check (idempotent: same content always gets same sid)
-        cached = self.storage.get_cached_compressed(sid)
+        # The model is fed model_input when supplied, so kind must be classified
+        # from the same text. Doing it here rather than at step 5 lets the cache
+        # key carry the resolved kind instead of the caller's None.
+        model_text = model_input if model_input is not None else content
+        if kind is None:
+            kind = classify_kind_from_content(model_text)
+
+        # The compressed result depends on query, level and kind as well as on the
+        # content -- query is documented as driving keep/drop -- so all four belong
+        # in the key. Keying on content alone returned the first caller's answer to
+        # every later caller: a different intent and a different level came back
+        # byte-identical, with cache_hit=True and nothing to say which intent
+        # produced it. `sid` deliberately stays content-only, because expand_context
+        # resolves originals by content and that behaviour is correct.
+        cache_key = content_hash(
+            "\x00".join([sid, level or "", kind or "", query or ""])
+        )
+
+        # 4. Cache check (same content AND same intent gets the same answer)
+        cached = self.storage.get_cached_compressed(cache_key)
         if cached is not None:
             if source:
                 self.storage.set_shadow_for_path(source, sid)
@@ -223,15 +241,11 @@ class CompressionPipeline:
                 metadata={"cache_hit": True},
             )
 
-        # 5. Call model (SEG protocol: intent + kind + level). Feed model_input when
-        # given (e.g. line-numbered form) — content still governs everything else.
-        model_text = model_input if model_input is not None else content
-        # Classify kind centrally so every backend receives a real kind. Without
-        # this only LocalModelStrategy sniffs it internally; GpuServerStrategy would
-        # forward kind=None to the server. Classify on model_text (what the model
-        # actually sees), matching the local fallback.
-        if kind is None:
-            kind = classify_kind_from_content(model_text)
+        # 5. Call model (SEG protocol: intent + kind + level). model_text and kind
+        # are resolved above, before the cache key is built, so that every backend
+        # receives a real kind and the key reflects it. Without central
+        # classification only LocalModelStrategy sniffs kind internally;
+        # GpuServerStrategy would forward kind=None to the server.
         compressed = self._model.compress(
             model_text,
             query=query,
@@ -255,7 +269,7 @@ class CompressionPipeline:
             self.storage.set_shadow_for_path(source, sid)
         else:
             tagged = f"[REF:{sid}] {compressed}"
-        self.storage.cache_compressed(sid, tagged)
+        self.storage.cache_compressed(cache_key, tagged)
 
         tagged_tokens = count_tokens(tagged, enc)
 

--- a/tests/test_cache_key_intent.py
+++ b/tests/test_cache_key_intent.py
@@ -1,0 +1,92 @@
+"""Regression: the compressed-result cache was keyed on content alone.
+
+`sid = content_hash(content)` was used both as the shadow id and as the cache
+key, so the first caller's answer was returned to every later caller regardless
+of what they asked for:
+
+    query="Fix the IntegrityError"             level=L0  -> 159 tok, cache_hit=False
+    query="Explain the tax rounding TODO"      level=L3  -> 159 tok, cache_hit=True
+    identical output: yes
+
+That is worse than an ordinary stale-cache bug, because `query` is documented as
+"USER INTENT -- the agent's current task. Drives keep/drop." Query-conditioned
+compression stops happening the moment the same bytes are seen twice, which in a
+coding agent is constant: the same file across turns, the same test output after
+a re-run, the same schema every request.
+
+`level` was affected the same way, and it looks like "levels do nothing" -- L0
+through L3 come back byte-identical, and only the timings (9.6s, then 0.0s,
+0.0s, 0.0s) reveal it as a cache hit.
+
+The key now covers content, level, kind and query. `sid` stays content-only on
+purpose: expand_context resolves originals by content and that is correct.
+"""
+
+from paritok import CompressionPipeline, ParitokConfig
+
+CONTENT = (
+    '  File "app/db/session.py", line 214, in commit\n'
+    "sqlalchemy.exc.IntegrityError: duplicate key 0x1f4 violates \"orders_pkey\"\n"
+    "def compute_tax(amount, rate):\n    return amount * rate  # TODO rounding\n"
+) * 40
+
+
+class _RecordingModel:
+    """Returns a distinct answer per (query, level) so cache reuse is visible."""
+
+    def __init__(self):
+        self.calls = []
+
+    def compress(self, text, *, query=None, level=None, kind=None, **_):
+        self.calls.append((query, level, kind))
+        return f"compressed for query={query!r} level={level!r}"
+
+
+def _pipeline():
+    pipeline = CompressionPipeline(ParitokConfig.load())
+    model = _RecordingModel()
+    pipeline._model = model
+    return pipeline, model
+
+
+def test_a_different_query_is_not_served_from_cache():
+    pipeline, model = _pipeline()
+
+    first = pipeline.compress(CONTENT, query="Fix the IntegrityError", kind="tool_output")
+    second = pipeline.compress(CONTENT, query="Explain the rounding TODO", kind="tool_output")
+
+    assert first.metadata.get("cache_hit") is not True
+    assert second.metadata.get("cache_hit") is not True
+    assert first.compressed != second.compressed
+    assert len(model.calls) == 2, "the second intent must reach the model"
+
+
+def test_a_different_level_is_not_served_from_cache():
+    pipeline, model = _pipeline()
+
+    low = pipeline.compress(CONTENT, query="same", kind="tool_output", level="L0")
+    high = pipeline.compress(CONTENT, query="same", kind="tool_output", level="L3")
+
+    assert low.compressed != high.compressed
+    assert [c[1] for c in model.calls] == ["L0", "L3"]
+
+
+def test_an_identical_call_still_hits_the_cache():
+    """The fix must not turn the cache off."""
+    pipeline, model = _pipeline()
+
+    pipeline.compress(CONTENT, query="same", kind="tool_output", level="L1")
+    again = pipeline.compress(CONTENT, query="same", kind="tool_output", level="L1")
+
+    assert again.metadata.get("cache_hit") is True
+    assert len(model.calls) == 1, "an identical call must not reach the model twice"
+
+
+def test_shadow_id_stays_content_only():
+    """expand_context resolves by content; widening the cache key must not touch it."""
+    pipeline, _ = _pipeline()
+
+    first = pipeline.compress(CONTENT, query="one intent", kind="tool_output", level="L0")
+    second = pipeline.compress(CONTENT, query="another intent", kind="tool_output", level="L3")
+
+    assert first.shadow_id == second.shadow_id

--- a/tests/test_path_shortcircuit_after_cache_fix.py
+++ b/tests/test_path_shortcircuit_after_cache_fix.py
@@ -1,0 +1,73 @@
+"""Regression: widening the cache key must not disable the path short-circuit.
+
+The intent-aware cache key (query/level/kind widened, see
+test_cache_key_intent.py) stores results under `cache_key`, but the path
+short-circuit at step 1b resolves a prior [REF] tag by the content-only
+`sid`. If the result is only stored under `cache_key`, every re-read of the
+same source file misses the short-circuit and re-invokes the model.
+
+The fix indexes the tagged result under both keys.
+"""
+
+from paritok import CompressionPipeline, ParitokConfig
+
+
+class _RecordingModel:
+    def __init__(self):
+        self.calls = []
+
+    def compress(self, text, *, query=None, level=None, kind=None, **_):
+        self.calls.append((query, level, kind))
+        return f"compressed<{query}|{level}>"
+
+
+def _pipeline():
+    pipeline = CompressionPipeline(ParitokConfig.load())
+    model = _RecordingModel()
+    pipeline._model = model
+    return pipeline, model
+
+
+def _file(n):
+    return "".join(f"def f{i}(a, b):\n    return a * b + {i}\n" for i in range(n))
+
+
+def test_partial_re_read_still_short_circuits():
+    """A re-read of the same source must reuse the existing [REF] tag."""
+    pipeline, model = _pipeline()
+
+    first = pipeline.compress(
+        _file(200), query="first intent", kind="file_read", source="/app/tax.py"
+    )
+    assert first.metadata.get("cache_hit") is False
+
+    second = pipeline.compress(
+        _file(100), query="second intent", kind="file_read", source="/app/tax.py"
+    )
+
+    assert second.metadata.get("path_shortcircuit") is True
+    assert second.shadow_id == first.shadow_id
+    assert len(model.calls) == 1, "the re-read must not reach the model"
+
+
+def test_full_re_read_still_short_circuits():
+    pipeline, model = _pipeline()
+
+    pipeline.compress(_file(200), query="one", kind="file_read", source="/app/tax.py")
+    again = pipeline.compress(_file(200), query="two", kind="file_read", source="/app/tax.py")
+
+    assert again.metadata.get("path_shortcircuit") is True
+    assert len(model.calls) == 1
+
+
+def test_intent_cache_isolation_survives_the_dual_write():
+    """The sid-indexed copy must not leak across intents on the sourceless path."""
+    pipeline, model = _pipeline()
+    content = _file(200)
+
+    first = pipeline.compress(content, query="fix the bug", kind="tool_output")
+    second = pipeline.compress(content, query="explain the design", kind="tool_output")
+
+    assert first.compressed != second.compressed
+    assert second.metadata.get("cache_hit") is False
+    assert len(model.calls) == 2


### PR DESCRIPTION
This builds on #17 (I've kept @EazyHood's original commit, all credit to them for finding the cache bug). While testing that patch I hit a regression it introduces, so this PR is #17 plus the fix for that.

## The problem

#17 moves the compressed-result cache from the content-only `sid` to a wider key that includes query/level/kind. That part is correct. But results are now stored only under the new key, while the path short-circuit at step 1b still looks things up by `prior_sid`:

```python
cached_tag = self.storage.get_cached_compressed(prior_sid)   # never hits after #17
```

So after #17, re-reading a file that was already compressed doesn't short-circuit anymore — it goes back to the model. I noticed it because a partial re-read that returns `path_shortcircuit: true` on main was suddenly making a second model call on the #17 branch. None of the existing tests caught it since nothing exercises step 1b after a compression.

For agent traffic this matters a lot: the same file gets re-read across turns constantly, and each of those becomes a fresh GPU call. That's the exact cost the short-circuit was added to avoid.

## Fix

Store the tagged result under the content-only sid as well:

```python
self.storage.cache_compressed(cache_key, tagged)
self.storage.cache_compressed(sid, tagged)   # step 1b resolves by sid
```

I checked who reads that key — only step 1b does, so this doesn't leak answers across intents on the normal path (there's a test asserting two different queries still make two model calls). Re-read behaviour ends up byte-identical to main. The short-circuit already ignores intent by design on main, and I didn't change that. Cost is one extra SET per compression, same TTL, works the same on the memory and redis backends.

## Tests

Added `tests/test_path_shortcircuit_after_cache_fix.py` with three cases: partial re-read short-circuits, full re-read short-circuits, and different intents staying isolated despite the extra write. With #17's own four cache tests, the full suite is 98 passed.