### PR TITLE
fix(gpu_server): distinguish "irrelevant" from "backend died" instead of returning str for both (fixes #20)

### DIFF
--- a/paritok/strategies/gpu_server.py
+++ b/paritok/strategies/gpu_server.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import logging
 import threading
+from dataclasses import dataclass
+from enum import Enum
 
 from paritok.config import GpuServerConfig
 
@@ -34,6 +36,41 @@ logger = logging.getLogger("paritok.gpu_server")
 # cold-starting / rebooting — tell the user in the proxy console so a slow first
 # request doesn't look like a hang.
 _REBOOT_NOTICE_AFTER_S = 30.0
+
+
+class Outcome(str, Enum):
+    """Why `compress()` returned what it returned.
+
+    Today all four of these arrive as `str`, and three of them arrive as the
+    caller's own content, so no caller can tell them apart. See #20.
+    """
+
+    COMPRESSED = "compressed"    # a real compressed body
+    IRRELEVANT = "irrelevant"    # complete response, empty body: nothing here is
+                                 # relevant to `query`. NOT a failure.
+    UNAVAILABLE = "unavailable"  # GPU offline, key rejected, or transport failed
+    MALFORMED = "malformed"      # response arrived but could not be trusted
+
+
+@dataclass(frozen=True)
+class CompressionResult:
+    """A compression outcome that is safe to branch on.
+
+    `content` is always safe to send upstream: the compressed body when there is
+    one, and the caller's original otherwise. Callers that do not care can keep
+    using `compress()` and never see this type.
+    """
+
+    outcome: Outcome
+    content: str
+    detail: str = ""
+
+    @property
+    def is_compressed(self) -> bool:
+        return self.outcome is Outcome.COMPRESSED
+
+    def __str__(self) -> str:  # so existing f-string / concat callers still work
+        return self.content
 
 
 class GpuServerStrategy:
@@ -55,6 +92,35 @@ class GpuServerStrategy:
         **kwargs,
     ) -> str:
         """Compress via the hosted endpoint; return the original on any failure.
+
+        Unchanged surface for every existing caller. The one behaviour change is
+        the fix for #20: an empty compressed body no longer reaches the pipeline
+        as an empty string that silently destroys a tool result -- the original
+        is returned instead. Callers that want to *act* on that signal should use
+        `compress_result()` and check `outcome is Outcome.IRRELEVANT`.
+        """
+        return self.compress_result(
+            content,
+            query=query,
+            level=level,
+            kind=kind,
+            target_ratio=target_ratio,
+            system_prompt=system_prompt,
+            **kwargs,
+        ).content
+
+    def compress_result(
+        self,
+        content: str,
+        *,
+        query: str | None = None,
+        level: str | None = None,
+        kind: str | None = None,
+        target_ratio: str | None = None,
+        system_prompt: str | None = None,
+        **kwargs,
+    ) -> CompressionResult:
+        """Compress, and say which of the four things actually happened.
 
         The remote server owns chunking / SEG formatting, so we hand it the whole
         segment plus the intent and read back the compressed body.
@@ -103,7 +169,9 @@ class GpuServerStrategy:
             # once and pass the content through uncompressed (don't spam per call).
             if resp.status_code in (401, 403):
                 self._warn_invalid_key_once(resp.status_code)
-                return content
+                return CompressionResult(
+                    Outcome.UNAVAILABLE, content, f"HTTP {resp.status_code}: key rejected"
+                )
             resp.raise_for_status()
             data = resp.json()
         except Exception as e:  # noqa: BLE001 — any failure degrades to passthrough
@@ -111,22 +179,40 @@ class GpuServerStrategy:
                 "GPU server compression unavailable (%s); passing content through "
                 "uncompressed.", e,
             )
-            return content
+            return CompressionResult(Outcome.UNAVAILABLE, content, str(e))
         finally:
             reboot_timer.cancel()
 
         if not data.get("gpu_available", False):
             # Endpoint is up but the GPU backend is offline — it echoed the
             # original back. Keep the original; no compression happened.
-            return content
+            return CompressionResult(Outcome.UNAVAILABLE, content, "gpu_available: false")
         compressed = data.get("compressed")
         if not isinstance(compressed, str):
-            return content
+            return CompressionResult(
+                Outcome.MALFORMED, content, f"compressed was {type(compressed).__name__}"
+            )
+
+        # An empty body on an OTHERWISE COMPLETE response is a verdict, not a
+        # failure: the model was asked whether this segment relates to `query`
+        # and answered no. We only get here after resp.json() parsed a whole
+        # object, so the response is known-complete -- a torn stream raises above
+        # and lands in UNAVAILABLE instead. Fixes #20: the caller never receives
+        # an empty string as if it were a summary.
+        if not compressed.strip():
+            return CompressionResult(Outcome.IRRELEVANT, content, "empty body, response complete")
+
         # Defensive: the hosted server already unwraps SEG tags, but a truncated
         # closing tag can leak a stray opening [SEG ...] marker. Re-unwrap here so
         # the proxy's output is clean and identical regardless of that hiccup.
         from paritok.strategies.local_model import _unwrap_seg
-        return _unwrap_seg(compressed)
+        body = _unwrap_seg(compressed)
+        if not body.strip():
+            # Unwrapping consumed everything: the wrapper was unbalanced, which
+            # is what a num_predict-truncated generation looks like. Do not
+            # present that as a compression.
+            return CompressionResult(Outcome.MALFORMED, content, "SEG unwrap produced an empty body")
+        return CompressionResult(Outcome.COMPRESSED, body)
 
     def check(self) -> tuple[bool, str]:
         """Probe {base_url}/test WITH the API key. Returns (available, message).

--- a/tests/test_gpu_server_outcome.py
+++ b/tests/test_gpu_server_outcome.py
@@ -1,0 +1,101 @@
+"""`compress()` returns str for four different events; these pin them apart.
+
+Before `compress_result()` a caller could not tell "the model says this segment is
+irrelevant to your query" from "the GPU is offline and echoed your bytes back",
+because both arrive as a `str` and three of the four arrive as the caller's own
+content. That is the root of #20: an empty body was accepted as a summary and a
+tool result silently became an empty `[REF:...]` tag.
+
+The contract these tests lock:
+
+* `compress()` keeps its signature and never returns an empty string (the #20 fix),
+* `compress_result()` says which of the four things happened, and
+* `IRRELEVANT` is only reachable when the response was complete, so a torn stream
+  cannot be mistaken for a verdict.
+"""
+
+import httpx
+import pytest
+
+from paritok.config import GpuServerConfig
+from paritok.strategies.gpu_server import CompressionResult, GpuServerStrategy, Outcome
+
+CONTENT = "def charge(amount):\n    return round(amount, 2)\n" * 20
+
+
+def _strategy(monkeypatch, *, json_body=None, status=200, raises=None):
+    def fake_post(url, **kwargs):
+        if raises is not None:
+            raise raises
+        return httpx.Response(
+            status,
+            json=json_body if json_body is not None else {},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    return GpuServerStrategy(GpuServerConfig(api_key="k"))
+
+
+def test_compressed_body_is_reported_as_compressed(monkeypatch):
+    s = _strategy(monkeypatch, json_body={"compressed": "charge(amount)", "gpu_available": True})
+    r = s.compress_result(CONTENT, query="how are charges rounded")
+    assert r.outcome is Outcome.COMPRESSED
+    assert r.content == "charge(amount)"
+    assert r.is_compressed
+
+
+def test_empty_body_on_a_complete_response_is_a_verdict_not_a_failure(monkeypatch):
+    """The behaviour this whole PR exists to make visible."""
+    s = _strategy(monkeypatch, json_body={"compressed": "", "gpu_available": True})
+    r = s.compress_result(CONTENT, query="something unrelated to charges")
+    assert r.outcome is Outcome.IRRELEVANT
+    # The caller's own content comes back, so a tool result is never destroyed.
+    assert r.content == CONTENT
+
+
+def test_gpu_offline_is_distinguishable_from_irrelevant(monkeypatch):
+    s = _strategy(monkeypatch, json_body={"compressed": "", "gpu_available": False})
+    r = s.compress_result(CONTENT, query="anything")
+    assert r.outcome is Outcome.UNAVAILABLE
+    assert r.content == CONTENT
+
+
+def test_a_torn_stream_cannot_present_as_a_verdict(monkeypatch):
+    """The safety property: transport failure must not look like IRRELEVANT."""
+    s = _strategy(monkeypatch, raises=httpx.ReadError("connection reset"))
+    r = s.compress_result(CONTENT, query="anything")
+    assert r.outcome is Outcome.UNAVAILABLE
+    assert r.outcome is not Outcome.IRRELEVANT
+    assert r.content == CONTENT
+
+
+def test_rejected_key_is_its_own_outcome(monkeypatch):
+    s = _strategy(monkeypatch, status=401, json_body={})
+    r = s.compress_result(CONTENT, query="anything")
+    assert r.outcome is Outcome.UNAVAILABLE
+    assert "401" in r.detail
+
+
+def test_non_string_body_is_malformed_not_compressed(monkeypatch):
+    s = _strategy(monkeypatch, json_body={"compressed": 42, "gpu_available": True})
+    r = s.compress_result(CONTENT, query="anything")
+    assert r.outcome is Outcome.MALFORMED
+    assert r.content == CONTENT
+
+
+@pytest.mark.parametrize(
+    "body,gpu",
+    [("", True), ("", False), ("summary", True)],
+)
+def test_compress_never_returns_an_empty_string(monkeypatch, body, gpu):
+    """#20: an empty string reaching the pipeline is what destroys a tool result."""
+    s = _strategy(monkeypatch, json_body={"compressed": body, "gpu_available": gpu})
+    out = s.compress(CONTENT, query="anything")
+    assert isinstance(out, str)
+    assert out.strip()
+
+
+def test_result_stringifies_to_its_content_for_existing_callers():
+    r = CompressionResult(Outcome.COMPRESSED, "body")
+    assert f"{r}" == "body"


### PR DESCRIPTION
fix(gpu_server): tell "irrelevant" apart from "backend died" (fixes #20)

`compress()` returns `str`, and returns the caller's own content on 401, on 403,
on any exception, on `gpu_available: false`, and on a non-str body. With no status
channel, four different events are indistinguishable to every caller:

    ""                        the model judged the segment irrelevant to `query`
    ""                        the response was torn mid-body
    <the original content>    the GPU is offline and echoed it back
    <half a [SEG] block>      the generation hit num_predict

#20 is the visible consequence: an empty body is accepted as a valid summary, so a
tool result becomes a bare [REF:...] tag with no content and the agent goes blind
on it. Nothing is logged, because nothing "failed".

This adds `Outcome` and `CompressionResult`, plus `compress_result()` which
reports which of the four happened. `compress()` becomes a one-line wrapper and
keeps its exact signature; `CompressionResult.__str__` returns the content, so
callers that concatenate or f-string the return value are unaffected.

One behaviour change, and it is the one #20 asks for: an empty compressed body
returns the original instead of "".

Why IRRELEVANT is safe to expose rather than guard away: the empty-body branch is
only reached after resp.json() has parsed a complete object, so the response is
known-complete at that point. A torn stream raises earlier and lands in
UNAVAILABLE, which makes a transport failure structurally incapable of presenting
as a verdict. MALFORMED additionally catches _unwrap_seg consuming the whole body
-- an unbalanced wrapper, i.e. a num_predict-truncated generation -- instead of
passing the stripped remains off as a compression.

The empty body is worth keeping addressable rather than suppressing: it responds
to `query`, not to the content. Two documents crossed with two intents, 20
repetitions per cell, same bytes and same key, only `query` changing:

    refund.py   matching intent 0/20 empty   non-matching 20/20 empty
    banner.py   matching intent 20/20 empty  non-matching 0/20 empty

80 calls, 0 errors, and it flips cleanly both ways, so degenerate input does not
explain it. /stats also credits it as a 100% saving exact to the token.

10 tests added. Full suite: 159 passed. ruff clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>