### PR TITLE
fix(gpu_server): send an explicit User-Agent so a rejected client is not reported as a bad API key

### DIFF
--- a/paritok/strategies/gpu_server.py
+++ b/paritok/strategies/gpu_server.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import threading
 
+from paritok import __version__
 from paritok.config import GpuServerConfig
 
 logger = logging.getLogger("paritok.gpu_server")
@@ -34,6 +35,17 @@ logger = logging.getLogger("paritok.gpu_server")
 # cold-starting / rebooting — tell the user in the proxy console so a slow first
 # request doesn't look like a hang.
 _REBOOT_NOTICE_AFTER_S = 30.0
+
+# Sent on every hosted request. Two reasons this is explicit rather than left to
+# the HTTP client's default:
+#
+# 1. The endpoint rejects some default agents. `urllib.request` -- the obvious
+#    choice for a dependency-free repro script -- gets HTTP 403 with no body, and
+#    403 is also what a rejected API key returns, so `_warn_invalid_key_once()`
+#    fires and tells the user their key is bad when it is fine.
+# 2. Hosted traffic becomes attributable to a client and version without the
+#    server having to guess.
+_USER_AGENT = f"paritok/{__version__} (+https://github.com/Paritok-official/paritok-4b-v1)"
 
 
 class GpuServerStrategy:
@@ -80,7 +92,7 @@ class GpuServerStrategy:
         upstream_model = kwargs.get("upstream_model")
         if upstream_model:
             payload["upstream_model"] = upstream_model
-        headers = {}
+        headers = {"User-Agent": _USER_AGENT}
         if self.config.api_key:
             headers["Authorization"] = f"Bearer {self.config.api_key}"
 
@@ -146,7 +158,7 @@ class GpuServerStrategy:
                 "(pip install paritok[llm])."
             )
 
-        headers = {}
+        headers = {"User-Agent": _USER_AGENT}
         if self.config.api_key:
             headers["Authorization"] = f"Bearer {self.config.api_key}"
 

--- a/tests/test_gpu_server_user_agent.py
+++ b/tests/test_gpu_server_user_agent.py
@@ -1,0 +1,65 @@
+"""Both hosted calls must identify the client.
+
+The endpoint rejects some default User-Agents with HTTP 403 and an empty body.
+`urllib.request` is one of them, which is the natural choice for a
+dependency-free repro script -- and 403 is the same status a rejected API key
+returns, so the client prints "Paritok API key not valid" at someone whose key is
+perfectly good.
+
+Sending an explicit agent removes that failure mode and makes hosted traffic
+attributable. `check()` matters as much as `compress()` here: it is the call that
+runs at startup, so it is the one most likely to produce the misleading message.
+"""
+
+import httpx
+
+from paritok import __version__
+from paritok.config import GpuServerConfig
+from paritok.strategies.gpu_server import GpuServerStrategy
+
+
+def _capture(monkeypatch, method):
+    seen = {}
+
+    def fake(url, **kwargs):
+        seen["headers"] = kwargs.get("headers") or {}
+        return httpx.Response(
+            200,
+            json={"compressed": "x", "gpu_available": True, "message": "ok"},
+            request=httpx.Request(method.upper(), url),
+        )
+
+    monkeypatch.setattr(httpx, method, fake)
+    return seen
+
+
+def test_compress_sends_an_explicit_user_agent(monkeypatch):
+    seen = _capture(monkeypatch, "post")
+    GpuServerStrategy(GpuServerConfig(api_key="k")).compress("x" * 400, query="q")
+    assert seen["headers"].get("User-Agent", "").startswith("paritok/")
+
+
+def test_check_sends_an_explicit_user_agent(monkeypatch):
+    """startup path: the one that produces the misleading key warning"""
+    seen = _capture(monkeypatch, "get")
+    GpuServerStrategy(GpuServerConfig(api_key="k")).check()
+    assert seen["headers"].get("User-Agent", "").startswith("paritok/")
+
+
+def test_user_agent_carries_the_version(monkeypatch):
+    seen = _capture(monkeypatch, "post")
+    GpuServerStrategy(GpuServerConfig(api_key="k")).compress("x" * 400, query="q")
+    assert __version__ in seen["headers"]["User-Agent"]
+
+
+def test_authorization_is_still_sent(monkeypatch):
+    seen = _capture(monkeypatch, "post")
+    GpuServerStrategy(GpuServerConfig(api_key="secret")).compress("x" * 400, query="q")
+    assert seen["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_user_agent_is_sent_even_without_a_key(monkeypatch):
+    seen = _capture(monkeypatch, "post")
+    GpuServerStrategy(GpuServerConfig(api_key="")).compress("x" * 400, query="q")
+    assert "User-Agent" in seen["headers"]
+    assert "Authorization" not in seen["headers"]


### PR DESCRIPTION
fix(gpu_server): send an explicit User-Agent so a rejected client is not reported as a bad key

`POST /api/compress` returns HTTP 403 with an empty body when the request carries
the Python standard library's default agent (`Python-urllib/3.x`). The same key,
same payload and same endpoint succeed from httpx or curl.

The confusing part is not the 403, it is what the client does with it: 403 is also
the status a rejected API key returns, so `_warn_invalid_key_once()` fires and
prints

    [paritok] Paritok API key not valid (HTTP 403: the API key was rejected).
    Compression is passing through UNCOMPRESSED

at someone whose key is fine. Anyone reaching for `urllib.request` to write a
dependency-free repro -- a reasonable instinct for a one-file script -- is sent
off to regenerate a working key.

Repro:

    req = urllib.request.Request(
        "https://www.paritok.com/api/compress",
        data=json.dumps({"model": "paritok-4b-v1", "content": src, "query": q}).encode(),
        headers={"Authorization": "Bearer <key>", "Content-Type": "application/json"},
    )
    urllib.request.urlopen(req)     # HTTP 403

Adding `"User-Agent": "curl/8.0"` to those headers makes the identical request
succeed.

This sends `paritok/<version>` from both hosted call sites. It sidesteps the
rejection for anyone using the shipped strategy and makes hosted traffic
attributable to a client and version. `check()` is included deliberately -- it is
the startup call, so it is the one most likely to produce the misleading message.

If the filter is intentional bot mitigation, a distinct status or a body such as
{"error": "unsupported client"} would still be worth having server-side, so it is
not indistinguishable from an auth failure.

5 tests added. Full suite: 154 passed. ruff clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>