### PR TITLE
feat(gpu_server): add verify(), because /test can report healthy while /compress passes everything through

### DIFF
--- a/paritok/strategies/gpu_server.py
+++ b/paritok/strategies/gpu_server.py
@@ -182,6 +182,58 @@ class GpuServerStrategy:
             )
         return bool(data.get("gpu_available", False)), str(data.get("message", ""))
 
+    # A canary that is verifiably irrelevant to the query it is sent with. The
+    # hosted model returns an empty body for content unrelated to `query`, so a
+    # NON-empty reply here means relevance filtering is not running -- which is
+    # exactly the state /test does not report.
+    _CANARY = (
+        '"""ASCII banner helpers."""\nimport shutil\n\n\n'
+        "def terminal_width(default=80):\n"
+        "    try:\n        return shutil.get_terminal_size().columns\n"
+        "    except OSError:\n        return default\n\n\n"
+        "def render_banner(text, char='=', padding=2):\n"
+        "    width = terminal_width()\n"
+        "    inner = ' ' * padding + text + ' ' * padding\n"
+        "    return char * 4 + inner + char * 4\n"
+    ) * 3
+    _CANARY_QUERY = "fix the refund amount validation in payments/refund.py"
+
+    def verify(self) -> tuple[bool, str]:
+        """Is the backend actually COMPRESSING, as opposed to merely reachable?
+
+        `check()` asks /test, and /test has been observed reporting
+        `gpu_available: true` while /compress returned `gpu_available: false` and
+        passed every request through uncompressed (reproduced 5 times over 35
+        minutes). Startup therefore reports healthy, and the user's traffic is
+        silently uncompressed with no error anywhere -- the worst shape a failure
+        can take, because it is invisible and it inflates cost rather than
+        breaking anything.
+
+        This probes /compress itself with a canary that is irrelevant to the query
+        it is sent with, and reports what actually came back. It costs one small
+        request and is the only answer that cannot be contradicted by the endpoint
+        it is describing.
+        """
+        try:
+            import httpx  # noqa: F401
+        except ImportError:
+            return False, "httpx is required for the gpu_server strategy."
+
+        out = self.compress(self._CANARY, query=self._CANARY_QUERY)
+        if not out.strip():
+            return True, "compressing: canary irrelevant to the query returned empty"
+        # Compared stripped: compress() routes the body through _unwrap_seg(),
+        # which trims, so a byte-for-byte passthrough comes back one character
+        # shorter than it went out and an `==` here silently misses it.
+        if out.strip() == self._CANARY.strip():
+            return False, (
+                "NOT compressing: the canary came back byte-identical. The endpoint "
+                "is reachable but passing content through uncompressed -- the state "
+                "/test does not report. Treat any savings from this session as "
+                "unmeasured."
+            )
+        return True, "compressing: canary returned a compressed body"
+
     def _warn_invalid_key_once(self, status: int) -> None:
         """Print a one-time console warning when the hosted endpoint rejects our
         API key (HTTP 401/403). Requests keep working (passed through

--- a/tests/test_gpu_server_verify.py
+++ b/tests/test_gpu_server_verify.py
@@ -1,0 +1,70 @@
+"""`check()` asks /test; `verify()` asks the endpoint that actually does the work.
+
+/test has been observed reporting `gpu_available: true` while /compress returned
+`gpu_available: false` and passed every request through uncompressed. Startup
+reports healthy, traffic is silently uncompressed, and nothing errors -- so the
+one case these tests care about is the disagreement: `check()` says yes and
+`verify()` says no.
+"""
+
+import httpx
+
+from paritok.config import GpuServerConfig
+from paritok.strategies.gpu_server import GpuServerStrategy
+
+
+def _endpoint(monkeypatch, *, test_says=True, compress_returns=""):
+    """Wire /test and /compress independently so they can disagree."""
+
+    def fake_get(url, **kwargs):
+        return httpx.Response(
+            200,
+            json={"gpu_available": test_says, "message": "ok"},
+            request=httpx.Request("GET", url),
+        )
+
+    def fake_post(url, **kwargs):
+        body = kwargs["json"]["content"] if compress_returns is PASSTHROUGH else compress_returns
+        return httpx.Response(
+            200,
+            json={"compressed": body, "gpu_available": True},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    monkeypatch.setattr(httpx, "post", fake_post)
+    return GpuServerStrategy(GpuServerConfig(api_key="k"))
+
+
+PASSTHROUGH = object()
+
+
+def test_empty_canary_means_relevance_filtering_is_running(monkeypatch):
+    s = _endpoint(monkeypatch, compress_returns="")
+    ok, msg = s.verify()
+    assert ok
+    assert "compressing" in msg
+
+
+def test_a_compressed_canary_also_counts_as_working(monkeypatch):
+    s = _endpoint(monkeypatch, compress_returns="banner helpers")
+    ok, _ = s.verify()
+    assert ok
+
+
+def test_passthrough_is_caught_even_though_test_reports_healthy(monkeypatch):
+    """The reported defect, in one assertion pair."""
+    s = _endpoint(monkeypatch, test_says=True, compress_returns=PASSTHROUGH)
+
+    available, _ = s.check()
+    assert available is True          # /test is happy
+
+    ok, msg = s.verify()
+    assert ok is False                # /compress is not
+    assert "NOT compressing" in msg
+
+
+def test_verify_does_not_contradict_check_when_the_backend_is_fine(monkeypatch):
+    s = _endpoint(monkeypatch, test_says=True, compress_returns="")
+    assert s.check()[0] is True
+    assert s.verify()[0] is True


### PR DESCRIPTION
feat(gpu_server): add verify(), because /test can report healthy while /compress passes everything through

`check()` asks /test. /test has been observed answering `gpu_available: true`
while /compress returned `gpu_available: false` and passed every request through
uncompressed -- reproduced 5 times over 35 minutes.

That combination is the worst shape a failure can take. Startup reports healthy,
`compress()` degrades to passthrough exactly as designed, nothing raises, nothing
logs, and the user's traffic is silently uncompressed. It does not break anything;
it just quietly stops doing the one thing the library is for, and inflates cost
while reporting success. We lost three repositories of benchmark data to it
before noticing, because a passthrough result is flattering AND indistinguishable
from a real one once written down.

`verify()` asks the endpoint that actually does the work. It POSTs a canary that
is deliberately irrelevant to the query it is sent with -- the hosted model
returns an empty body for content unrelated to `query` -- and reports what came
back:

    empty            relevance filtering is running
    compressed body  compressing
    the canary, verbatim   NOT compressing; passing content through

`check()` is untouched, so nothing changes for existing callers. This is additive
and costs one small request when called.

One detail worth flagging for reviewers, because the test caught it and an `==`
would have shipped broken: `compress()` routes the body through `_unwrap_seg()`,
which trims, so a byte-for-byte passthrough returns one character shorter than it
went out. The comparison is therefore made on stripped text.

4 tests added, including the disagreement case: check() reports available while
verify() reports NOT compressing. Full suite: 153 passed. ruff clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>