### PR TITLE
fix(gpu_server): warn once that the hosted backend ignores `level` (#3)

### DIFF
--- a/paritok/strategies/gpu_server.py
+++ b/paritok/strategies/gpu_server.py
@@ -42,6 +42,7 @@ class GpuServerStrategy:
     def __init__(self, config: GpuServerConfig):
         self.config = config
         self._key_warned = False  # warn about a rejected API key only once
+        self._level_warned = False  # warn once that hosted ignores `level`
 
     def compress(
         self,
@@ -66,6 +67,9 @@ class GpuServerStrategy:
                 "httpx is required for the gpu_server strategy. "
                 "Install with: pip install paritok[llm]"
             )
+
+        if level is not None:
+            self._warn_level_ignored_once(level)
 
         payload = {
             "model": self.config.model,
@@ -181,6 +185,26 @@ class GpuServerStrategy:
                 "Compression will pass through uncompressed."
             )
         return bool(data.get("gpu_available", False)), str(data.get("message", ""))
+
+    def _warn_level_ignored_once(self, level: str) -> None:
+        """Say once that `level` does nothing on the hosted backend.
+
+        The parameter is accepted, serialised into the payload and sent, and the
+        hosted endpoint ignores it (maintainer, #3). Nothing on either side says
+        so, so a caller implementing an L2 -> L1 -> L0 fallback ladder gets the
+        same output at every rung and reasonably concludes their own logic is
+        wrong. Silence here costs debugging time that the one-line warning does
+        not.
+        """
+        if self._level_warned:
+            return
+        self._level_warned = True
+        logger.warning(
+            "level=%r was passed, but the hosted backend ignores it (see "
+            "Paritok-official/paritok-4b-v1#3); every level returns the same "
+            "output. Use the self-hosted backend if you need the level dial.",
+            level,
+        )
 
     def _warn_invalid_key_once(self, status: int) -> None:
         """Print a one-time console warning when the hosted endpoint rejects our

--- a/tests/test_gpu_server_level_warning.py
+++ b/tests/test_gpu_server_level_warning.py
@@ -1,0 +1,71 @@
+"""`level` is accepted, sent, and ignored by the hosted backend (#3).
+
+Nothing on either side says so. A caller implementing the documented
+L2 -> L1 -> L0 fallback ladder gets byte-identical output at every rung and
+concludes their own logic is broken. One warning, once per strategy, removes an
+afternoon of debugging.
+
+Once, specifically: `compress()` is called per segment, so warning per call would
+put thousands of identical lines through the proxy console -- the same reason
+`_warn_invalid_key_once` exists.
+"""
+
+import logging
+
+import httpx
+
+from paritok.config import GpuServerConfig
+from paritok.strategies.gpu_server import GpuServerStrategy
+
+CONTENT = "def charge(amount):\n    return round(amount, 2)\n" * 20
+
+
+def _strategy(monkeypatch):
+    def fake_post(url, **kwargs):
+        return httpx.Response(
+            200,
+            json={"compressed": "summary", "gpu_available": True},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    return GpuServerStrategy(GpuServerConfig(api_key="k"))
+
+
+def test_passing_a_level_warns(monkeypatch, caplog):
+    s = _strategy(monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="paritok.gpu_server"):
+        s.compress(CONTENT, query="q", level="L2")
+    assert any("ignores it" in m for m in (r.getMessage() for r in caplog.records))
+
+
+def test_it_warns_only_once_however_many_segments(monkeypatch, caplog):
+    s = _strategy(monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="paritok.gpu_server"):
+        for _ in range(50):
+            s.compress(CONTENT, query="q", level="L1")
+    assert len(caplog.records) == 1
+
+
+def test_no_warning_when_no_level_is_passed(monkeypatch, caplog):
+    s = _strategy(monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="paritok.gpu_server"):
+        s.compress(CONTENT, query="q")
+    assert caplog.records == []
+
+
+def test_the_level_is_still_sent_unchanged(monkeypatch):
+    """A warning, not a behaviour change: the payload is untouched."""
+    seen = {}
+
+    def fake_post(url, **kwargs):
+        seen.update(kwargs["json"])
+        return httpx.Response(
+            200,
+            json={"compressed": "summary", "gpu_available": True},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    GpuServerStrategy(GpuServerConfig(api_key="k")).compress(CONTENT, query="q", level="L0")
+    assert seen["level"] == "L0"


### PR DESCRIPTION
fix(gpu_server): say once that the hosted backend ignores `level` (#3)

`level` is accepted by `compress()`, serialised into the payload, and sent. The
hosted endpoint ignores it (maintainer, #3). Neither side says so.

The cost lands on anyone implementing the documented L2 -> L1 -> L0 fallback
ladder: every rung returns byte-identical output, so the obvious conclusion is
that your own fallback logic is broken, and you go looking for the bug in your
code. We reimplemented that ladder for a benchmark and it collapsed to a single
real rung -- the final fall back to the original -- which is what any
implementation of that strategy silently reduces to on hosted.

This logs one warning naming #3 the first time a level is passed. Once per
strategy, not per call: `compress()` runs per segment, and a corpus scan would
otherwise put thousands of identical lines through the proxy console. That is the
same reason `_warn_invalid_key_once` exists.

Deliberately a warning and not a behaviour change: `level` is still sent
unchanged, so if the hosted backend starts honouring it nothing here has to be
undone, and self-hosted is unaffected. A test pins that the payload is untouched.

4 tests added. Full suite: 153 passed. ruff clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>