### PR TITLE
fix(pricing): add current MiniMax models

### DIFF
--- a/paritok/proxy/pricing.py
+++ b/paritok/proxy/pricing.py
@@ -36,6 +36,9 @@ INPUT_USD_PER_MTOK: dict[str, float] = {
     "o4-mini": 1.10,
     "o3-mini": 1.10,
     "o3": 2.00,
+    # MiniMax
+    "minimax-m3": 0.60,
+    "minimax-m2.7": 0.30,
 }
 
 # Cache-READ multiplier: what a provider charges for an input token served from

--- a/paritok/proxy/pricing.py
+++ b/paritok/proxy/pricing.py
@@ -37,7 +37,10 @@ INPUT_USD_PER_MTOK: dict[str, float] = {
     "o3-mini": 1.10,
     "o3": 2.00,
     # MiniMax
-    "minimax-m3": 0.60,
+    # M3 is tiered on input length: $0.30/M at <=512K, $0.60/M above it. This
+    # table holds one flat standard rate per model, so we use the <=512K tier —
+    # the common case. Cost estimates under-count a >512K-context request by ~2x.
+    "minimax-m3": 0.30,
     "minimax-m2.7": 0.30,
 }
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,16 @@
+import pytest
+
+from paritok.proxy.pricing import input_usd_per_mtok
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_price"),
+    [
+        ("MiniMax-M3", 0.60),
+        ("MiniMax-M2.7", 0.30),
+        ("minimax/MiniMax-M3", 0.60),
+        ("minimax/MiniMax-M2.7", 0.30),
+    ],
+)
+def test_minimax_input_prices(model, expected_price):
+    assert input_usd_per_mtok(model) == (expected_price, True)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -6,9 +6,9 @@ from paritok.proxy.pricing import input_usd_per_mtok
 @pytest.mark.parametrize(
     ("model", "expected_price"),
     [
-        ("MiniMax-M3", 0.60),
+        ("MiniMax-M3", 0.30),
         ("MiniMax-M2.7", 0.30),
-        ("minimax/MiniMax-M3", 0.60),
+        ("minimax/MiniMax-M3", 0.30),
         ("minimax/MiniMax-M2.7", 0.30),
     ],
 )


### PR DESCRIPTION
Reason: The pricing registry treats MiniMax-M3 and MiniMax-M2.7 as unknown models and applies the fallback input price.

This change:
- registers the current per-million input prices for MiniMax-M3 and MiniMax-M2.7
- verifies exact and provider-prefixed model identifiers

Checks:
- `uv run --with pytest pytest tests/test_pricing.py -q`
- `uv run --with pytest --with starlette pytest -q`
- `uv run --with ruff ruff check .`
