### PR TITLE
Add `paritok doctor`: preflight that fails on silent no-op compression

### DIFF
--- a/paritok/cli.py
+++ b/paritok/cli.py
@@ -150,6 +150,153 @@ def config():
     click.echo(f"\nShadow Storage: {cfg.shadow_storage}")
 
 
+# Content for the compression smoke test: repetitive tool output, which is the
+# easy case for the compressor. If this does not shrink, nothing will.
+_SMOKE_CONTENT = "".join(
+    f"  File \"/app/handlers/route_{i}.py\", line {i}, in dispatch\n"
+    f"    raise ValueError(f\"unroutable payload {{payload!r}}\")  # frame {i}\n"
+    for i in range(60)
+)
+_SMOKE_QUERY = "Which handler raises ValueError on an unroutable payload?"
+_SMOKE_MAX_RATIO = 0.9
+
+
+def _ok(msg, detail=""):
+    click.echo(f"  {click.style('OK', fg='green')}   {msg}" + (f" — {detail}" if detail else ""))
+
+
+def _warn(msg, detail=""):
+    click.echo(f"  {click.style('WARN', fg='yellow')} {msg}" + (f" — {detail}" if detail else ""))
+
+
+def _fail(msg, detail=""):
+    click.echo(f"  {click.style('FAIL', fg='red')} {msg}" + (f" — {detail}" if detail else ""))
+
+
+@main.command()
+@click.option("--config-file", default=None, type=click.Path(exists=True),
+              help="Path to YAML config file")
+@click.option("--port", default=8080, type=int, show_default=True,
+              help="Port to check for a running proxy.")
+@click.option("--host", default="127.0.0.1", show_default=True,
+              help="Host to check for a running proxy.")
+def doctor(config_file, port, host):
+    """Check that compression is actually wired up and working.
+
+    Verifies the backend is reachable AND that a block round-trips materially
+    smaller. The second check is the point: /test reporting healthy does not mean
+    the worker is compressing. When it is not, compress() correctly passes the
+    original through, the proxy returns HTTP 200, and /stats shows
+    `tokens_saved: 0` — which is indistinguishable from "nothing here was
+    compressible" unless you look closely. This command makes that state loud.
+
+    Exits non-zero if any check fails, so it can gate a CI job or a smoke test.
+    """
+    # Same discovery rule as `proxy` / `up`: an explicit --config-file wins,
+    # otherwise pick up a paritok.yaml sitting in the current folder. Checking a
+    # different config than the proxy will actually run would defeat the point.
+    if config_file is None and os.path.exists(_DEFAULT_CONFIG_NAME):
+        config_file = _DEFAULT_CONFIG_NAME
+    cfg = ParitokConfig.load(config_file) if config_file else ParitokConfig.load()
+
+    failures = 0
+    warnings = 0
+
+    click.echo("\nParitok doctor\n" + "-" * 56)
+
+    # -- configuration ----------------------------------------------------
+    click.echo("\nConfiguration")
+    backend = "hosted GPU server" if cfg.use_gpu_server else "self-hosted (Ollama)"
+    _ok("backend", f"{backend} (use_gpu_server: {cfg.use_gpu_server})")
+
+    if cfg.use_gpu_server:
+        if cfg.gpu_server.api_key:
+            _ok("gpu_server.api_key", "set")
+        else:
+            _fail("gpu_server.api_key", "missing — set it in paritok.yaml or PARITOK_API_KEY")
+            failures += 1
+    else:
+        _ok("local_model", f"{cfg.local_model.model} at {cfg.local_model.base_url}")
+
+    # -- backend reachable ------------------------------------------------
+    click.echo("\nBackend")
+    if cfg.use_gpu_server:
+        from paritok.strategies.gpu_server import GpuServerStrategy
+        strategy = GpuServerStrategy(cfg.gpu_server)
+        available, message = strategy.check()
+        if available:
+            _ok("hosted endpoint", message or cfg.gpu_server.base_url)
+        else:
+            _fail("hosted endpoint", message)
+            failures += 1
+    else:
+        from paritok.strategies.local_model import LocalModelStrategy
+        strategy = LocalModelStrategy(cfg.local_model)
+        if strategy.is_available():
+            _ok("Ollama model", f"{cfg.local_model.model} responding")
+        else:
+            _fail("Ollama model", (
+                f"{cfg.local_model.model} not available at {cfg.local_model.base_url}. "
+                "Run: ollama pull paritok/paritok-4b-v1 && "
+                "ollama cp paritok/paritok-4b-v1 paritok-4b-v1"
+            ))
+            failures += 1
+
+    # -- the check that /test cannot do -----------------------------------
+    click.echo("\nCompression")
+    if failures:
+        _warn("smoke test", "skipped — fix the failures above first")
+    else:
+        original = _SMOKE_CONTENT
+        try:
+            compressed = strategy.compress(original, query=_SMOKE_QUERY, kind="log_output")
+        except Exception as e:  # noqa: BLE001 — any failure here is a failed check
+            _fail("smoke test", f"{type(e).__name__}: {e}")
+            failures += 1
+            compressed = None
+
+        if compressed is not None:
+            ratio = len(compressed) / len(original) if original else 1.0
+            summary = f"{len(original):,} → {len(compressed):,} chars (ratio {ratio:.2f})"
+            if ratio <= _SMOKE_MAX_RATIO:
+                _ok("smoke test", summary)
+            else:
+                _fail("smoke test", (
+                    f"{summary}. The backend answered but did not compress, so every "
+                    "request will pass through at full size while still returning 200."
+                ))
+                failures += 1
+
+    # -- proxy, if one is running -----------------------------------------
+    click.echo("\nProxy")
+    stats_url = f"http://{host}:{port}/stats"
+    try:
+        import httpx
+        resp = httpx.get(stats_url, timeout=5.0)
+        if resp.status_code == 200:
+            data = resp.json()
+            _ok("proxy", f"up on {host}:{port} — {data.get('total_requests', 0)} requests seen")
+        else:
+            _warn("proxy", f"{stats_url} returned HTTP {resp.status_code}")
+            warnings += 1
+    except Exception:  # noqa: BLE001 — not running is normal, not an error
+        _warn("proxy", f"nothing listening on {host}:{port} (fine if you have not started it)")
+        warnings += 1
+
+    # -- verdict ----------------------------------------------------------
+    click.echo("-" * 56)
+    if failures:
+        click.echo(
+            f"\n{failures} check(s) failed. Compression is not working end to end; "
+            "any token savings you measure will be zero.\n"
+        )
+        raise SystemExit(1)
+    if warnings:
+        click.echo(f"\nAll critical checks passed ({warnings} warning(s)).\n")
+    else:
+        click.echo("\nAll checks passed. Compression is live.\n")
+
+
 @main.command()
 @click.option("--host", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", default=8080, type=int, help="Port to listen on")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,102 @@
+"""`paritok doctor` — a preflight that fails when compression is a silent no-op.
+
+The gap this closes: GET /test reporting `gpu_available: true` does not mean the
+worker is compressing. When it is not, compress() correctly returns the original
+(gpu_server.py), the proxy answers HTTP 200, and /stats shows `tokens_saved: 0` —
+which looks the same as "nothing in this content was compressible". Issues #20,
+#30 and #31 all start from someone unable to tell those apart.
+
+So the doctor does not just probe reachability; it round-trips a block and fails
+if the result is not materially smaller.
+"""
+import click.testing
+
+from paritok.cli import main
+
+
+class _FakeStrategy:
+    """Stands in for GpuServerStrategy / LocalModelStrategy."""
+
+    def __init__(self, available=True, message="GPU server online.", ratio=0.05, raises=None):
+        self._available = available
+        self._message = message
+        self._ratio = ratio
+        self._raises = raises
+
+    def check(self):
+        return self._available, self._message
+
+    def is_available(self):
+        return self._available
+
+    def compress(self, content, **kwargs):
+        if self._raises is not None:
+            raise self._raises
+        # ratio 1.0 == the backend echoed the input back == a silent no-op.
+        return content[: max(1, int(len(content) * self._ratio))]
+
+
+def _run(monkeypatch, strategy, use_gpu_server=True, api_key="pk_live_test"):
+    from paritok.config import GpuServerConfig, ParitokConfig
+
+    cfg = ParitokConfig()
+    cfg.use_gpu_server = use_gpu_server
+    if use_gpu_server:
+        cfg.gpu_server = GpuServerConfig(
+            base_url="https://www.paritok.com/api", model="paritok-4b-v1",
+            api_key=api_key, timeout=10.0,
+        )
+    monkeypatch.setattr(ParitokConfig, "load", staticmethod(lambda *a, **k: cfg))
+    monkeypatch.setattr(
+        "paritok.strategies.gpu_server.GpuServerStrategy", lambda *a, **k: strategy
+    )
+    monkeypatch.setattr(
+        "paritok.strategies.local_model.LocalModelStrategy", lambda *a, **k: strategy
+    )
+    # No proxy running: the doctor should warn, not fail.
+    import httpx
+
+    def _no_proxy(*a, **k):
+        raise httpx.ConnectError("nothing listening")
+
+    monkeypatch.setattr(httpx, "get", _no_proxy)
+    return click.testing.CliRunner().invoke(main, ["doctor"])
+
+
+def test_passes_when_backend_reachable_and_compressing(monkeypatch):
+    result = _run(monkeypatch, _FakeStrategy(ratio=0.05))
+    assert result.exit_code == 0, result.output
+    assert "All critical checks passed" in result.output or "All checks passed" in result.output
+
+
+def test_fails_when_backend_answers_but_does_not_compress(monkeypatch):
+    """The regression that motivates this command: healthy endpoint, no compression."""
+    result = _run(monkeypatch, _FakeStrategy(ratio=1.0))
+    assert result.exit_code == 1
+    assert "did not compress" in result.output
+
+
+def test_fails_when_backend_unreachable(monkeypatch):
+    result = _run(monkeypatch, _FakeStrategy(available=False, message="unreachable"))
+    assert result.exit_code == 1
+    assert "unreachable" in result.output
+    # The smoke test must not run against a backend we already know is down.
+    assert "skipped" in result.output
+
+
+def test_fails_when_api_key_missing(monkeypatch):
+    result = _run(monkeypatch, _FakeStrategy(), api_key="")
+    assert result.exit_code == 1
+    assert "api_key" in result.output
+
+
+def test_fails_when_compress_raises(monkeypatch):
+    result = _run(monkeypatch, _FakeStrategy(raises=RuntimeError("boom")))
+    assert result.exit_code == 1
+    assert "RuntimeError" in result.output
+
+
+def test_missing_proxy_is_a_warning_not_a_failure(monkeypatch):
+    result = _run(monkeypatch, _FakeStrategy(ratio=0.05))
+    assert result.exit_code == 0
+    assert "nothing listening" in result.output


### PR DESCRIPTION
Closes the preflight half of #29. Follows on from #31, and picks up the canary
idea from #34 in the place you suggested it belongs.

## Framing, updated after reading #34

I opened this before seeing that you'd closed #34 earlier today. Recapping so the
justification here is current rather than stale:

- `/api/test` now reads RunPod's real worker state, so `check()` is honest at
  startup and the "healthy while `/compress` passes everything through" shape is
  caught at the source.
- The client trace now records `gpu_unavailable` rather than
  `below_refusal_threshold` on a passthrough.

**So the argument I'd originally have made for this — "`/test` can lie" — is no
longer the reason.** You fixed that. What's left is your own note on #34: *"The
end-to-end canary idea is still a good one, though — it fits better as part of a
`paritok doctor` preflight (#29) than in the strategy's hot path."* That's what
this is.

One thing worth flagging: the canary here is **not** affected by the obsolescence
you pointed out on #34. That one relied on "irrelevant content → empty body",
which no longer holds now that dropped content returns an `IRRELEVANT_STUB`. This
one sends content that *is* relevant to its query and asserts the result comes
back materially smaller, so it tests the compressing path directly and doesn't
depend on the drop signal at all.

## Why it still earns its place

Not as a second opinion on `check()` — as one command that walks the whole chain
and gives CI a non-zero exit:

- config discovery (the same rule `proxy`/`up` use) and credentials
- backend reachable — reusing `check()` / `is_available()`, not re-implementing
- **an end-to-end compression canary** — the one thing no status endpoint can
  answer, since it exercises the actual path a user's traffic takes
- the proxy, if one is listening

## What it looks like

```
$ paritok doctor

Paritok doctor
--------------------------------------------------------

Configuration
  OK   backend — hosted GPU server (use_gpu_server: True)
  OK   gpu_server.api_key — set

Backend
  OK   hosted endpoint — GPU server online (RunPod serverless).

Compression
  OK   smoke test — 7,470 → 4,465 chars (ratio 0.60)

Proxy
  WARN proxy — nothing listening on 127.0.0.1:8080 (fine if you have not started it)
--------------------------------------------------------

All critical checks passed (1 warning(s)).
```

- **Exits non-zero on failure**, so it can gate a CI job.
- A missing proxy is a *warning*, not a failure — `doctor` is most useful before
  you start one.
- The canary is skipped when the backend is already known to be down, so the
  output points at one root cause instead of two.
- Config discovery matches `proxy` / `up`: `--config-file` wins, otherwise a
  `paritok.yaml` in the current folder. Checking a different config than the proxy
  will actually run would defeat the purpose.
- Works on both backends — `compress()` is common to `GpuServerStrategy` and
  `LocalModelStrategy`.

## Verification

- `289 passed, 1 skipped` — full suite, `pip install -e ".[proxy]"`
- Six new tests in `tests/test_doctor.py`: pass path, **backend answers but doesn't
  compress**, unreachable backend, missing key, `compress()` raising, and
  missing-proxy-is-a-warning
- Against the live hosted GPU: passes while compressing (7,470 → 4,465 chars),
  exits `1` on a rejected key

## Open questions for review

- **Threshold.** `ratio > 0.9` → fail. Deliberately loose — it's there to catch a
  *no-op*, not to grade compression quality. Happy to move it to config.
- **Scope.** I left out the `requests_compressed` / `blocks_found` counters per
  your note on #31, since #42's stats UI is the better home for that.
- If you'd rather the canary lived as a reusable helper (something like the
  `verify()` shape from #34, but called only from `doctor` rather than the hot
  path), say so and I'll restructure.

Originally built as `headroom doctor` while benchmarking Paritok
([Headroom](https://github.com/Shivang-creator/headroom)) — this is it ported to
your CLI conventions. Happy to adjust naming, output, or scope.
