### PR TITLE
feat(proxy): report the installed paritok version from /health

### DIFF
--- a/paritok/proxy/server.py
+++ b/paritok/proxy/server.py
@@ -1160,7 +1160,15 @@ def create_app(
         return JSONResponse(proxy_stats.snapshot())
 
     async def handle_health(request: Request) -> JSONResponse:
-        return JSONResponse({"status": "ok", "version": "1.0.0"})
+        # Report the installed package version instead of a frozen literal, so
+        # health checks / dashboards can tell which proxy build is running.
+        try:
+            from importlib.metadata import version
+
+            v = version("paritok")
+        except Exception:
+            v = "unknown"
+        return JSONResponse({"status": "ok", "version": v})
 
     # ── Helpers ──
 


### PR DESCRIPTION
`handle_health` returns a hardcoded `"version": "1.0.0"` that never tracks releases,
so health checks and dashboards can't tell which proxy build is running (the package
is on 1.3.x). This resolves it from `importlib.metadata.version("paritok")`, falling
back to `"unknown"` if metadata isn't available.

```python
    async def handle_health(request: Request) -> JSONResponse:
        try:
            from importlib.metadata import version
            v = version("paritok")
        except Exception:
            v = "unknown"
        return JSONResponse({"status": "ok", "version": v})
```

## Apply

```bash
cd <paritok-4b-v1 repo root>
git checkout -b feat/health-version
git apply --check /path/to/pr2/health-reports-real-version.patch
git apply         /path/to/pr2/health-reports-real-version.patch
git add -A && git commit -m "feat(proxy): report the installed paritok version from /health"
gh pr create --title "feat(proxy): report the installed paritok version from /health" --body-file /path/to/pr2/PR.md
```
