### PR TITLE
docs: add OrcaRouter to OpenAI-compatible upstream examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ The gateway is independent of the upstream LLM — point the OpenAI path at **an
 ```bash
 paritok proxy --openai-url https://api.groq.com/openai        # Groq
 paritok proxy --openai-url https://openrouter.ai/api/v1       # OpenRouter
+paritok proxy --openai-url https://api.orcarouter.ai/v1       # OrcaRouter
 ```
 
 Then point your OpenAI-SDK agent at the proxy (`OPENAI_BASE_URL=http://127.0.0.1:8080`), set `OPENAI_API_KEY` to the provider's key, and use that provider's model names.


### PR DESCRIPTION
## What

Paritok's README already points OpenAI-SDK agents at any Chat-Completions-compatible upstream via `--openai-url`, with named examples for Groq and OpenRouter. This adds [OrcaRouter](https://www.orcarouter.ai) to that list so Paritok users can route through it as a first-class provider instead of an anonymous base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- Add `paritok proxy --openai-url https://api.orcarouter.ai/v1   # OrcaRouter` to the "Any OpenAI-compatible upstream (Groq, Gemini, OpenRouter, …)" example block in `README.md`, mirroring the existing Groq/OpenRouter lines.

## Verification

- `ruff check .` passes on the repo.
- Live check: `curl -X POST https://api.orcarouter.ai/v1/chat/completions` with model `openai/gpt-4o-mini` returns HTTP 200, so the endpoint and the `/v1` versioning work with Paritok's existing `_openai_chat_url` resolution (the path already carries `/v1`, so only `/chat/completions` is appended).

## Contact

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
